### PR TITLE
Decouple CardPileUI from JSON file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ This plugin provides a flexible and customizable card pile user interface for th
 
 | Return          | Name                                                                   | Description                                                                       |
 |-----------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `void`          | `create_card_in_dropzone(nice_name : String, dropzone : CardDropzone)` | Creates a new instance of the named card in the given dropzone                    |
-| `void`          | `create_card_in_pile(nice_name : String, pile_to_add_to : Piles)`      | Creates a new instance of the named card in the given pile                        |
+| `void`          | `create_card_in_dropzone(card_id, dropzone : CardDropzone)` | Creates a new instance of the named card in the given dropzone                    |
+| `void`          | `create_card_in_pile(card_id, pile_to_add_to : Piles)`      | Creates a new instance of the named card in the given pile                        |
 | `void`          | `discard_at(index : int)`                                              | Perform a typical "discard" action, moving card from the hand to the discard pile |
 | `void`          | `draw(amount : int = 1)`                                               | Perform a typical "draw" action, moving cards from the draw pile to the hand      |
 | `bool`          | `hand_is_at_max_capacity()`                                            | Checks if hand is at max_capacity (any more cards added to it will be discarded)  |

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ This plugin provides a flexible and customizable card pile user interface for th
 <a name="getting-started"></a>
 ## Getting Started
 
-1. Create a script extending `CardUIData` that describes any custom properties your card will need. You can utlize inheritance here as needed. 
-2. Create a JSON database of your card information ([example](#json-database)).
-3. Create a JSON collection of your cards ([example](#json-collection)).
-4. Create a new scene with root type `CardUI` - this is the object that displays in game. This object must have 2 TextureRect as children named `Frontface` and `Backface`. It will warn you if configured incorrectly. 
+1. Create a custom resource script extending `CardUIData` that describes any custom properties your card will need. You can utlize inheritance here as needed.
+2. Create a database of your card information ([more info](#card-database))([example](#json-database)).
+3. Create a collection of your cards ([more info](#card-collection))([example](#json-collection)).
+4. Create a new scene with root type `CardUI` - this is the object that displays in game. This object must have 2 TextureRect as children named `Frontface` and `Backface`. It will warn you if configured incorrectly.
 5. Add a `CardPileUI` node to your game scene and configure its settings.
 6. Begin building your game with the provided methods and signals.
 
@@ -52,6 +52,10 @@ This plugin provides a flexible and customizable card pile user interface for th
 
 **Card UI Data** - this represents any custom data that your cards use.
 
+**Card Database** - container for all possible cards, represented by their `CardUIData`
+
+**Card Collection** - container for all cards currently in the game, ie. the deck. Can contain duplicates if the same card is present in the deck multiple times.
+
 **Card UI** - this is the in-game representation of your card data, this holds and displays **Card UI Data**
 
 **Card Dropzone** - this is a designated space where if a player drops a card something occurs. It can also stack cards, removing them from the standard draw/hand/discard piles.
@@ -59,7 +63,7 @@ This plugin provides a flexible and customizable card pile user interface for th
 **Draw Pile** - this is a pile containing cards that a player draws from during the game.
 
 **Hand Pile** - this is a pile containing cards currently held by a player.
-
+1
 **Discard Pile** - this is a pile containing cards that have been discarded during the game.
 
 **Card Removal from Game**, this occurs when a card is permanently removed from play
@@ -70,103 +74,157 @@ This plugin provides a flexible and customizable card pile user interface for th
 <a name="card-pile-ui-properties"></a>
 ### CardPileUI Properties
 
-| Type | Name | Default | Description
-|-|-|-|-
-| *Top Level* |-|-|-
-| String | json_card_database_path | null | Specifies the file path for the JSON database containing card information
-| String | json_card_collection_path | null | Defines the file path for the JSON file containing the card collection
-| PackedScene | extended_card_ui | null | A PackedScene for your extended `CardUI` scene.
-| *Pile Positions* |-|-|-
-| Vector2 | draw_pile_position | Vector2(20, 460) | Determines the position of the draw pile on the game screen.
-| Vector2 | hand_pile_position | Vector2(630, 460) | Determines the position of the hand pile on the game screen.
-| Vector2 | discard_pile_position | Vector2(1250, 460) | Determines the position of the discard pile on the game screen.
-| *Pile displays* |-|-|-
-| int | stack_display_gap | 8 | Sets the gap between displayed cards in a stack.
-| int | max_stack_display | 6 | Defines the maximum number of cards displayed in a stack.
-| *Cards* |-|-|-
-| float | card_speed | 0.1 | Sets the speed at which cards move within the game.
-| *Draw Pile* |-|-|-
-| bool | click_draw_pile_to_draw | true | Clicking the draw pile will trigger the `draw` method
-| bool | cant_draw_at_hand_limit | true | If hand is at max capacity, then the `draw` method is ignored. Otherwise cards that are drawn are immediately discarded
-| bool | shuffle_discard_on_empty_draw | true | Enables automatic shuffling of the discard pile into the draw pile when the draw pile is empty.
-| CardPileUI.PilesCardLayouts | draw_pile_layout | CardPileUI.PilesCardLayouts.up | Determines which direction the pile stacks
-| *Hand Pile* |-|-|-
-| bool | hand_enabled | true | Enables or disables the hand pile functionality.
-| bool | hand_face_up | true | Determines whether cards in the hand pile are face up or face down.
-| int | max_hand_size | 10 | Sets the maximum size of the hand. If exceeded, additional cards are immediately discarded.
-| int | max_hand_spread | 700 | Specifies the maximum spread distance of cards in the hand.
-| int | card_ui_hover_distance | 30 | Defines the distance at which the card UI responds to hover actions.
-| Curve | hand_rotation_curve | null | A curve for hand rotation. This works best as a 2-point line, rising linearly from -Y to +Y.
-| Curve | hand_vertical_curve | null | A curve for vertical hand movement. This works best as a 3-point line, easing in/out from 0 to Y to 0
-| *Discard Pile* |-|-|-
-| bool | discard_face_up | true | Determines whether cards in the discard pile are face up or face down.
-| CardPileUI.PilesCardLayouts | discard_pile_layout | CardPileUI.PilesCardLayouts.up | Determines which direction the pile stacks
+| Type                          | Name                            | Default                          | Description                                                                                                                             |
+|-------------------------------|---------------------------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| *Top Level*                   | -                               | -                                |                                                                                                                                         |
+| `CardDB`                      | `card_database`                 | `null`                           | Instance of card database containing card information                                                                                   |
+| `String` **_(deprecated)_**     | `json_card_database_path`       | `null`                           | For backwards compatibility only, use `card_database` instead                                                                           |
+| `CardCollection`              | `card_collection`               | `null`                           | Instance of card collection containing the current deck                                                                                 |
+| `String` **_(deprecated)_**     | `json_card_collection_path`     | `null`                           | Defines the file path for the JSON file containing the card collection. For backwards compatibility only, use `card_collection` instead |
+| `PackedScene`                 | `extended_card_ui`              | `null`                           | A PackedScene for your extended `CardUI` scene.                                                                                         |
+| *Pile Positions*              | -                               | -                                |                                                                                                                                         |
+| `Vector2`                     | `draw_pile_position`            | `Vector2(20, 460)`               | Determines the position of the draw pile on the game screen.                                                                            |
+| `Vector2`                     | `hand_pile_position`            | `Vector2(630, 460)`              | Determines the position of the hand pile on the game screen.                                                                            |
+| `Vector2`                     | `discard_pile_position`         | `Vector2(1250, 460)`             | Determines the position of the discard pile on the game screen.                                                                         |
+| *Pile displays*               | -                               | -                                |                                                                                                                                         |
+| `int`                         | `stack_display_gap`             | `8`                              | Sets the gap between displayed cards in a stack.                                                                                        |
+| `int`                         | `max_stack_display`             | `6`                              | Defines the maximum number of cards displayed in a stack.                                                                               |
+| *Cards*                       | -                               | -                                |                                                                                                                                         |
+| `float`                       | `card_speed`                    | `0.1`                            | Sets the speed at which cards move within the game.                                                                                     |
+| *Draw Pile*                   | -                               | -                                |                                                                                                                                         |
+| `bool`                        | `click_draw_pile_to_draw`       | `true`                           | Clicking the draw pile will trigger the `draw` method                                                                                   |
+| `bool`                        | `cant_draw_at_hand_limit`       | `true`                           | If hand is at max capacity, then the `draw` method is ignored. Otherwise cards that are drawn are immediately discarded                 |
+| `bool`                        | `shuffle_discard_on_empty_draw` | `true`                           | Enables automatic shuffling of the discard pile into the draw pile when the draw pile is empty.                                         |
+| `CardPileUI.PilesCardLayouts` | `draw_pile_layout`              | `CardPileUI.PilesCardLayouts.up` | Determines which direction the pile stacks                                                                                              |
+| *Hand Pile*                   | -                               | -                                |                                                                                                                                         |
+| `bool`                        | `hand_enabled`                  | `true`                           | Enables or disables the hand pile functionality.                                                                                        |
+| `bool`                        | `hand_face_up`                  | `true`                           | Determines whether cards in the hand pile are face up or face down.                                                                     |
+| `int`                         | `max_hand_size`                 | `10`                             | Sets the maximum size of the hand. If exceeded, additional cards are immediately discarded.                                             |
+| `int`                         | `max_hand_spread`               | `700`                            | Specifies the maximum spread distance of cards in the hand.                                                                             |
+| `int`                         | `card_ui_hover_distance`        | `30`                             | Defines the distance at which the card UI responds to hover actions.                                                                    |
+| `Curve`                       | `hand_rotation_curve`           | `null`                           | A curve for hand rotation. This works best as a 2-point line, rising linearly from -Y to +Y.                                            |
+| `Curve`                       | `hand_vertical_curve`           | `null`                           | A curve for vertical hand movement. This works best as a 3-point line, easing in/out from 0 to Y to 0                                   |
+| *Discard Pile*                | `-`                             | -                                |                                                                                                                                         |
+| `bool`                        | `discard_face_up`               | `true`                           | Determines whether cards in the discard pile are face up or face down.                                                                  |
+| `CardPileUI.PilesCardLayouts` | `discard_pile_layout`           | `CardPileUI.PilesCardLayouts.up` | Determines which direction the pile stacks                                                                                              |
 
 <a name="card-pile-ui-methods"></a>
 ### CardPileUI Methods
 
-| Return  | Name                                     | Description                                                |
-|---------|------------------------------------------|------------------------------------------------------------|
-| void    | create_card_in_dropzone(nice_name : String, dropzone : CardDropzone) | Creates a new instance of the named card in the given dropzone|
-| void    | create_card_in_pile(nice_name : String, pile_to_add_to : Piles) | Creates a new instance of the named card in the given pile    |
-| void    | discard_at(index : int) | Perform a typical "discard" action, moving card from the hand to the discard pile|
-| void    | draw(amount : int = 1) | Perform a typical "draw" action, moving cards from the draw pile to the hand|
-| bool    | hand_is_at_max_capacity() | Checks if hand is at max_capacity (any more cards added to it will be discarded)|
-| CardDropzone | get_card_dropzone(card : CardUI ) | Returns the current dropzone of a given card
-| CardUI  | get_card_in_pile_at(pile : Piles, index : int) | Returns a piles card at a given index|
-| Array[CardUI]   | get_cards_in_pile(pile : Piles) | Returns an array of cards from the specified pile|
-| int     | get_card_pile_size(pile : Piles) | Returns the number of cards in a given pile|
-| void    | remove_card_from_game(card : CardUI) | Removes the specified card from the game|
-| void    | reset() | Resets all cards to the collection's initial state |
-| void    | set_card_dropzone(card : CardUI, dropzone : CardDropzone) | Moves the specified card to the designated CardDropzone|
-| void    | set_card_pile(card : CardUI, pile : Piles) | Moves the specified card to the designated pile|
-| void    | sort_hand(sort_func : Callable) | Sort the hand using a custom function|
+| Return          | Name                                                                   | Description                                                                       |
+|-----------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `void`          | `create_card_in_dropzone(nice_name : String, dropzone : CardDropzone)` | Creates a new instance of the named card in the given dropzone                    |
+| `void`          | `create_card_in_pile(nice_name : String, pile_to_add_to : Piles)`      | Creates a new instance of the named card in the given pile                        |
+| `void`          | `discard_at(index : int)`                                              | Perform a typical "discard" action, moving card from the hand to the discard pile |
+| `void`          | `draw(amount : int = 1)`                                               | Perform a typical "draw" action, moving cards from the draw pile to the hand      |
+| `bool`          | `hand_is_at_max_capacity()`                                            | Checks if hand is at max_capacity (any more cards added to it will be discarded)  |
+| `CardDropzone`  | `get_card_dropzone(card : CardUI )`                                    | Returns the current dropzone of a given card                                      |
+| `CardUI`        | `get_card_in_pile_at(pile : Piles, index : int)`                       | Returns a piles card at a given index                                             |
+| `Array[CardUI]` | `get_cards_in_pile(pile : Piles)`                                      | Returns an array of cards from the specified pile                                 |
+| `int`           | `get_card_pile_size(pile : Piles)`                                     | Returns the number of cards in a given pile                                       |
+| `void`          | `remove_card_from_game(card : CardUI)`                                 | Removes the specified card from the game                                          |
+| `void`          | `reset()`                                                              | Resets all cards to the collection's initial state                                |
+| `void`          | `set_card_dropzone(card : CardUI, dropzone : CardDropzone)`            | Moves the specified card to the designated CardDropzone                           |
+| `void`          | `set_card_pile(card : CardUI, pile : Piles)`                           | Moves the specified card to the designated pile                                   |
+| `void`          | `sort_hand(sort_func : Callable)`                                      | Sort the hand using a custom function                                             |
 
 <a name="card-pile-ui-signals"></a>
 ## CardPileUI Signals
 
-| Signal | Description |
-|-|-|
-| draw_pile_updated | Indicates that the draw pile has been updated |
-| hand_pile_updated | Indicates that the hand pile has been updated |
-| discard_pile_updated | Indicates that the discard pile has been updated |
-| card_removed_from_dropzone(dropzone : CardDropzone, card: CardUI) | Signals the removal of a card from the specified CardDropzone|
-| card_added_to_dropzone(dropzone : CardDropzone, card: CardUI) | Signals the addition of a card to the specified CardDropzone|
-| card_hovered(card: CardUI) | Indicates when a card is being hovered over |
-| card_unhovered(card: CardUI) | Indicates when a card is no longer being hovered over |
-| card_clicked(card: CardUI) | Signals a click event on a card |
-| card_dropped(card: CardUI) | Signals when a clicked card has been dropped |
-| card_removed_from_game(card: CardUI) | Signals the removal of a card from the overall game |
+| Signal                                                              | Description                                                   |
+|---------------------------------------------------------------------|---------------------------------------------------------------|
+| `draw_pile_updated`                                                 | Indicates that the draw pile has been updated                 |
+| `hand_pile_updated`                                                 | Indicates that the hand pile has been updated                 |
+| `discard_pile_updated`                                              | Indicates that the discard pile has been updated              |
+| `card_removed_from_dropzone(dropzone : CardDropzone, card: CardUI)` | Signals the removal of a card from the specified CardDropzone |
+| `card_added_to_dropzone(dropzone : CardDropzone, card: CardUI)`     | Signals the addition of a card to the specified CardDropzone  |
+| `card_hovered(card: CardUI)`                                        | Indicates when a card is being hovered over                   |
+| `card_unhovered(card: CardUI)`                                      | Indicates when a card is no longer being hovered over         |
+| `card_clicked(card: CardUI)`                                        | Signals a click event on a card                               |
+| `card_dropped(card: CardUI)`                                        | Signals when a clicked card has been dropped                  |
+| `card_removed_from_game(card: CardUI)`                              | Signals the removal of a card from the overall game           |
 
 ---
 
 <a name="card-dropzone-properties"></a>
 ### CardDropzone Properties
-| Type | Name | Default | Description
-|-|-|-|-
-| CardPileUI | card_pile_ui | null |Path to the dropzone's managing CardPileUI node |
-| bool | card_ui_face_up | true | Indicates if piled cards should be face up |
-| int | stack_display_gap | 8 | Sets the gap between displayed cards in a stack.
-| int | max_stack_display | 6 | Defines the maximum number of cards displayed in a stack.
-| CardPileUI.PilesCardLayouts | discard_pile_layout | CardPileUI.PilesCardLayouts.up | Determines which direction the pile stacks
+| Type                          | Name                  | Default                          | Description                                               |
+|-------------------------------|-----------------------|----------------------------------|-----------------------------------------------------------|
+| `CardPileUI`                  | `card_pile_ui`        | `null`                           | Path to the dropzone's managing CardPileUI node           |
+| `bool`                        | `card_ui_face_up`     | `true`                           | Indicates if piled cards should be face up                |
+| `int`                         | `stack_display_gap`   | `8`                              | Sets the gap between displayed cards in a stack.          |
+| `int`                         | `max_stack_display`   | `6`                              | Defines the maximum number of cards displayed in a stack. |
+| `CardPileUI.PilesCardLayouts` | `discard_pile_layout` | `CardPileUI.PilesCardLayouts.up` | Determines which direction the pile stacks                |
 
 <a name="card-dropzone-methods"></a>
 ### CardDropzone Methods
-| Return  | Name | Description |
-|-|-|-
-| bool | can_drop_card(card_ui : CardUI) | This determines if a card can be dropped on this dropzone. Note - this is only automatically checked when dropping a card, not programatically moving one. 
-| void | card_ui_dropped(card_ui : CardUI) | This triggers when a card has been added or dropped on this dropzone.
-| CardUI | get_card_at(index : int) | Returns the card at index
-| Array[CardUI] | get_held_cards() | Returns an array of all held cards
-| CardUI | get_top_card() | Returns the top card, which is the same thing as the last one in the array
-| int | get_total_held_cards() | Returns the total number of cards piled here
-| bool | is_holding(card : CardUI) | Returns true if this card is piled here
+| Return          | Name                                | Description                                                                                                                                                |
+|-----------------|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bool`          | `can_drop_card(card_ui : CardUI)`   | This determines if a card can be dropped on this dropzone. Note - this is only automatically checked when dropping a card, not programatically moving one. |
+| `void`          | `card_ui_dropped(card_ui : CardUI)` | This triggers when a card has been added or dropped on this dropzone.                                                                                      |
+| `CardUI`        | `get_card_at(index : int)`          | Returns the card at index                                                                                                                                  |
+| `Array[CardUI]` | `get_held_cards()`                  | Returns an array of all held cards                                                                                                                         |
+| `CardUI`        | `get_top_card()`                    | Returns the top card, which is the same thing as the last one in the array                                                                                 |
+| `int`           | `get_total_held_cards()`            | Returns the total number of cards piled here                                                                                                               |
+| `bool`          | `is_holding(card : CardUI)`         | Returns true if this card is piled here                                                                                                                    |
+
+<a name="card-ui-data"></a>
+### `CardUIData`
+`CardUIData` is a resource representing the information to display and
+use a single card. It can be subclassed as necessary to store more
+information relevant to your game, but at the minimum, it needs the
+following information stored in its properties:
+
+* `frontface_texture` - `Texture2D` which will be used by `CardUI` to present the obverse (front) of the card
+* `backface_texture` - `Texture2D` which will be used by `CardUI` to present the reverse (back) of the card
+* `nice_name` - Human-readable name for the card. Stock `CardUI` does
+  not show it by default, but the UI scene provided to `CardPileUI`
+  can make use of it (see `example/`)
+
+<a name="card-database"></a>
+### Card Database
+`CardDB` serves as the foundation for all card data in your game. It
+is a `Resource` responsible for loading the `CardUIData` for all cards
+that `CardPileUI` will use, and is the abstract base for all
+implementations which actually do the loading and retrieval.
+
+Any `CardDB` implementation needs to provide two methods:
+
+* `prepare()` - will be called at least once, before `CardPileUI`
+  makes any calls to `get_card()`. This allows the implementation to
+  perform any loading and/or processing that it might need to do
+* `get_card(card_id) -> CardUIData` - this will be called whenever
+  `CardPileUI` needs to access per-card data, and should return an
+  instance of `CardUIData` (or its subclass). `card_id` is an opaque
+  key that this database can understand. It can be anything the
+  implementation wishes to use. Since the key data are provided by the
+  caller code, `CardPileUI` does not know or care what they are. The
+  only restriction is that the `CardCollection` used (see below) must
+  contain keys the `CardDB` being used will understand
+
+There are two built-in implementations of `CardDB`:
+* `NullCardDB` - this implementation simply returns any `card_id` it
+  receives as-is and performs no loading or retrieval at all. This is
+  very useful if you already have a card storage system (for example,
+  as custom resources), and simply want to integrate `CardPileUI` into
+  your code
+* `JSONFileCardDB` - this is a database which loads its data from a
+  JSON file and uses strings representing card names as `card_id`
+
+**NOTE**: Earlier versions of `CardPileUI` had hardcoded loading of
+JSON files for the card database and collection. If you wish to
+continue using JSON files, it is recommended to migrate to
+`JSONFileCardDB` and `JSONFileCardCollection`. For backwards
+compatibility, if your code does not provide a database/collection and
+uses the deprecated JSON path properties, the JSON implementation will
+automatically be used as a fallback.
 
 <a name="json-database"></a>
-### Card Database JSON
-The Card Database serves as the foundation for all card data in your game. 
+#### `JSONFileCardDB`
 
-Minimally viable card database:
+`JSONFileCardDB` loads its card data from a JSON file, specified as a
+path. At least the following keys are required as a minimally viable
+card database:
 ```
 [
   {
@@ -178,20 +236,40 @@ Minimally viable card database:
 ]
 ```
 
-| Name | Description |
-|-|-
-| nice_name | A unique name for this card
-| texture_path | Filepath to the card's front texture
-| backface_texture_path | Filepath to the card's back texture
-| resource_script_path | Filepath to the card's resource script. If you don't need any custom functionality, you can point this to `res://addons/simple_card_pile_ui/card_ui_data.gd`
-| * | You can add more data as needed
+| Name                    | Description                                                                                                                                                  |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nice_name`             | A unique name for this card                                                                                                                                  |
+| `texture_path`          | Filepath to the card's front texture. Will be `load()`ed                                                                                                     |
+| `backface_texture_path` | Filepath to the card's back texture. Will be `load()`ed                                                                                                      |
+| `resource_script_path`  | Filepath to the card's resource script. If you don't need any custom functionality, you can point this to `res://addons/simple_card_pile_ui/card_ui_data.gd` |
+| *                       | You can add more data as needed                                                                                                                              |
 
+
+<a name="card-collection"></a>
+### `CardCollection`
+This represents the cards that begin in the draw pile (ie. the
+deck). Like `CardDB`, `CardCollection` is an abstract base class with
+a number of possible implementations. It only needs to provide one
+method:
+
+* `_get_all()` - getter for the `all` property, this should return a
+  list of all the cards in the deck, represented by their IDs
+  (ie. values which can be passed to `CardDB.get_card()`). For that
+  reason, the `CardCollection` being used needs to be compatible with
+  the `CardDB` in use
+
+There are two built-in implementations provided out of the box:
+
+* `JSONFileCardCollection` - loads and returns array of strings from
+  the provided JSON file path. Compatible with `JSONFileCardDB`
+* `NullCardCollection` - simply returns whatever was provided as its
+  `cards` property. Compatible with `NullCardDB`
 
 <a name="json-collection"></a>
-### Card Collection JSON
-This represents the cards that begin in the draw pile.
+#### `JSONFileCardCollection`
 
-Example:
+This implementation stores a list of strings which should correspond
+to the `nice_name`s of cards in the database. Example:
 ```
  [ "My Card", "My Card", "My Other Card", "My Other Card" ]
 ```

--- a/README.md
+++ b/README.md
@@ -8,18 +8,22 @@ This plugin provides a flexible and customizable card pile user interface for th
 
 ## Table of Contents
 
-- [Features](#features)
+- [Features:](#features)
 - [Installation](#installation)
 - [Getting Started](#getting-started)
 - [Concepts](#concepts)
 - [Documentation](#documentation)
-	- [CardPileUI Properties](#card-pile-ui-properties)
-	- [CardPileUI Methods](#card-pile-ui-methods)
-	- [CardPileUI Signals](#card-pile-ui-signals)
-	- [CardDropzone Methods](#card-dropzone-methods)
-	- [CardDropzone Properties](#card-dropzone-properties)
-- [Thanks](#thanks)
-- [Changelog](#change-log)
+    - [CardPileUI Properties](#cardpileui-properties)
+    - [CardPileUI Methods](#cardpileui-methods)
+    - [CardPileUI Signals](#cardpileui-signals)
+    - [CardDropzone Properties](#carddropzone-properties)
+    - [CardDropzone Methods](#carddropzone-methods)
+    - [Card UI Data](#card-ui-data)
+    - [Card Database](#card-database)
+    - [Card Collection](#card-collection)
+- [To Do List](#to-do-list)
+- [Thanks to](#thanks-to)
+- [Changelog](#changelog)
 
 
 <a name="features"></a>
@@ -129,7 +133,7 @@ This plugin provides a flexible and customizable card pile user interface for th
 | `void`          | `sort_hand(sort_func : Callable)`                                      | Sort the hand using a custom function                                             |
 
 <a name="card-pile-ui-signals"></a>
-## CardPileUI Signals
+### CardPileUI Signals
 
 | Signal                                                              | Description                                                   |
 |---------------------------------------------------------------------|---------------------------------------------------------------|
@@ -169,7 +173,7 @@ This plugin provides a flexible and customizable card pile user interface for th
 | `bool`          | `is_holding(card : CardUI)`         | Returns true if this card is piled here                                                                                                                    |
 
 <a name="card-ui-data"></a>
-### `CardUIData`
+### Card UI Data
 `CardUIData` is a resource representing the information to display and
 use a single card. It can be subclassed as necessary to store more
 information relevant to your game, but at the minimum, it needs the
@@ -246,11 +250,11 @@ card database:
 
 
 <a name="card-collection"></a>
-### `CardCollection`
-This represents the cards that begin in the draw pile (ie. the
-deck). Like `CardDB`, `CardCollection` is an abstract base class with
-a number of possible implementations. It only needs to provide one
-method:
+### Card Collection
+`CardCollection` represents the cards that begin in the draw pile
+(ie. the deck). Like `CardDB`, `CardCollection` is an abstract base
+class with a number of possible implementations. It only needs to
+provide one method:
 
 * `_get_all()` - getter for the `all` property, this should return a
   list of all the cards in the deck, represented by their IDs

--- a/addons/simple_card_pile_ui/card_db/card_collection.gd
+++ b/addons/simple_card_pile_ui/card_db/card_collection.gd
@@ -1,0 +1,11 @@
+class_name CardCollection extends Resource
+
+@export var all: Array:
+	get = _get_all
+
+func _get_all():
+	assert(false, "not implemented")
+
+func _validate_property(prop):
+	if prop.name == "all":
+		prop.usage |= PROPERTY_USAGE_READ_ONLY

--- a/addons/simple_card_pile_ui/card_db/card_db.gd
+++ b/addons/simple_card_pile_ui/card_db/card_db.gd
@@ -1,0 +1,13 @@
+class_name CardDB extends Resource
+
+## This method will be called at least once by [CardPileUI] before the
+## first call to [method get_card]. Any setup, loading, etc. should happen here
+func prepare():
+	pass
+
+## This method needs to be overridden to implement card retrieval.
+## [param card_id] is an arbitrary value provided by the user used to identify
+## the requested card. Each subclass decides what kind of ID it wants to use
+func get_card(card_id: Variant) -> Variant:
+	assert(false, "not implemented")
+	return null

--- a/addons/simple_card_pile_ui/card_db/json_file_card_collection.gd
+++ b/addons/simple_card_pile_ui/card_db/json_file_card_collection.gd
@@ -1,0 +1,20 @@
+class_name JSONFileCardCollection extends CardCollection
+
+@export var json_file_path: String
+
+var _cards: Array[String] = []
+
+func _load():
+	if not _cards and json_file_path:
+		var read = JSONFileCardDB._load_json(json_file_path)
+		_cards.assign(read)
+
+func _init(path = null):
+	if path:
+		json_file_path = path
+
+func _get_all():
+	# Have to call it here, since _init() is called before exported
+	# vars have been set
+	_load()
+	return _cards

--- a/addons/simple_card_pile_ui/card_db/json_file_card_db.gd
+++ b/addons/simple_card_pile_ui/card_db/json_file_card_db.gd
@@ -1,0 +1,40 @@
+class_name JSONFileCardDB extends CardDB
+
+@export_file("*.json") var json_file_path: String
+
+var cards: Array[CardUIData]
+
+func _init(path = null):
+	if path:
+		json_file_path = path
+
+static func _load_json(path):
+	if path:
+		var json = FileAccess.get_file_as_string(path)
+		var parsed = JSON.parse_string(json)
+		return parsed
+	return []
+
+## This method should be overridden to add custom processing in subclasses
+func _prepare_single_card(json):
+	var card = ResourceLoader.load(json.resource_script_path).new()
+	card.frontface_texture = load(json.texture_path)
+	card.backface_texture = load(json.backface_texture_path)
+
+	for key in json.keys():
+		if key not in ["texture_path", "backface_texture_path", "resource_script_path"]:
+			card[key] = json[key]
+
+	return card
+
+func prepare():
+	var json = _load_json(json_file_path)
+	cards.clear()
+	for raw_card in json:
+		cards.append(_prepare_single_card(raw_card))
+
+
+func get_card(card_id):
+	for card in cards:
+		if card.nice_name == card_id:
+			return card

--- a/addons/simple_card_pile_ui/card_db/null_card_collection.gd
+++ b/addons/simple_card_pile_ui/card_db/null_card_collection.gd
@@ -1,0 +1,6 @@
+class_name NullCardCollection extends CardCollection
+
+@export var cards: Array
+
+func _get_all():
+	return cards

--- a/addons/simple_card_pile_ui/card_db/null_card_collection.gd
+++ b/addons/simple_card_pile_ui/card_db/null_card_collection.gd
@@ -1,6 +1,11 @@
+@tool
 class_name NullCardCollection extends CardCollection
 
 @export var cards: Array
 
 func _get_all():
 	return cards
+
+func _validate_property(property):
+	if property.name == "all":
+		property.usage &= ~PROPERTY_USAGE_EDITOR

--- a/addons/simple_card_pile_ui/card_db/null_card_db.gd
+++ b/addons/simple_card_pile_ui/card_db/null_card_db.gd
@@ -1,0 +1,7 @@
+class_name NullCardDB extends CardDB
+
+## This implementation expects cards to be provided externally
+## and simply returns them as-is when requested
+
+func get_card(card_id):
+	return card_id

--- a/addons/simple_card_pile_ui/card_pile_ui.gd
+++ b/addons/simple_card_pile_ui/card_pile_ui.gd
@@ -25,14 +25,14 @@ enum PilesCardLayouts {
 	down
 }
 
-## Deprecated, use card_database instead
+## Deprecated, use [member card_database] instead
 ## @deprecated
 @export_file("*.json") var json_card_database_path : String
-## Deprecated, use card_collection instead
+## Deprecated, use [member card_collection] instead
 ## @deprecated
 @export_file("*.json") var json_card_collection_path : String
 @export var card_database: CardDB
-@export var card_collection: Array
+@export var card_collection: CardCollection
 @export var extended_card_ui : PackedScene
 
 @export_group("Pile Positions")
@@ -201,7 +201,7 @@ func prepare_card_db():
 	if not card_database and json_card_database_path:
 		card_database = JSONFileCardDB.new(json_card_database_path)
 	if not card_collection and json_card_collection_path:
-		card_collection = JSONFileCardDB._load_json(json_card_collection_path)
+		card_collection = JSONFileCardCollection.new(json_card_collection_path)
 	card_database.prepare()
 
 func reset():
@@ -212,7 +212,7 @@ func _reset_card_collection():
 		_maybe_remove_card_from_any_piles(child)
 		_maybe_remove_card_from_any_dropzones(child)
 		remove_card_from_game(child)
-	for nice_name in card_collection:
+	for nice_name in card_collection.all:
 		var card_data = card_database.get_card(nice_name)
 		var card_ui = _create_card_ui(card_data)
 		_draw_pile.push_back(card_ui)

--- a/addons/simple_card_pile_ui/card_pile_ui.gd
+++ b/addons/simple_card_pile_ui/card_pile_ui.gd
@@ -156,13 +156,13 @@ func _maybe_remove_card_from_any_piles(card : CardUI):
 		discard_pile_updated.emit()
 
 
-func create_card_in_dropzone(nice_name : String, dropzone : CardDropzone):
-	var card_ui = _create_card_ui(card_database.get_card(nice_name))
+func create_card_in_dropzone(card_id, dropzone : CardDropzone):
+	var card_ui = _create_card_ui(card_database.get_card(card_id))
 	card_ui.position = dropzone.position
 	set_card_dropzone(card_ui, dropzone)
 
-func create_card_in_pile(nice_name : String, pile_to_add_to : Piles):
-	var card_ui = _create_card_ui(card_database.get_card(nice_name))
+func create_card_in_pile(card_id, pile_to_add_to : Piles):
+	var card_ui = _create_card_ui(card_database.get_card(card_id))
 	if pile_to_add_to == Piles.hand_pile:
 		card_ui.position = hand_pile_position
 	if pile_to_add_to == Piles.discard_pile:
@@ -212,8 +212,8 @@ func _reset_card_collection():
 		_maybe_remove_card_from_any_piles(child)
 		_maybe_remove_card_from_any_dropzones(child)
 		remove_card_from_game(child)
-	for nice_name in card_collection.all:
-		var card_data = card_database.get_card(nice_name)
+	for card_id in card_collection.all:
+		var card_data = card_database.get_card(card_id)
 		var card_ui = _create_card_ui(card_data)
 		_draw_pile.push_back(card_ui)
 		_draw_pile.shuffle()

--- a/addons/simple_card_pile_ui/card_pile_ui.gd
+++ b/addons/simple_card_pile_ui/card_pile_ui.gd
@@ -58,7 +58,7 @@ enum PilesCardLayouts {
 @export var hand_rotation_curve : Curve
 ## This works best as a 3-point ease in/out from 0 to X to 0
 @export var hand_vertical_curve : Curve
-#@export var drag_sort_enabled := true this would be nice to have, but based on how dragging works I'm not 100% sure how to handle it, possibly disable mouse input on the card being dragged? 
+#@export var drag_sort_enabled := true this would be nice to have, but based on how dragging works I'm not 100% sure how to handle it, possibly disable mouse input on the card being dragged?
 
 @export_group("Discard Pile")
 @export var discard_face_up := true
@@ -91,21 +91,21 @@ func set_card_pile(card : CardUI, pile : Piles):
 		_draw_pile.push_back(card)
 		emit_signal("draw_pile_updated")
 	reset_target_positions()
-	
+
 func set_card_dropzone(card : CardUI, dropzone : CardDropzone):
 	_maybe_remove_card_from_any_piles(card)
 	_maybe_remove_card_from_any_dropzones(card)
 	dropzone.add_card(card)
 	emit_signal("card_added_to_dropzone", dropzone, card)
 	reset_target_positions()
-	
+
 func remove_card_from_game(card : CardUI):
 	_maybe_remove_card_from_any_piles(card)
 	_maybe_remove_card_from_any_dropzones(card)
 	emit_signal("card_removed_from_game", card)
 	card.queue_free()
 	reset_target_positions()
-	
+
 func is_hand_enabled():
 	return hand_enabled
 
@@ -117,7 +117,7 @@ func get_cards_in_pile(pile : Piles):
 	elif pile == Piles.draw_pile:
 		return _draw_pile.duplicate()
 	return []
-	
+
 func get_card_in_pile_at(pile : Piles, index : int):
 	if pile == Piles.discard_pile and _discard_pile.size() > index:
 		return _discard_pile[index]
@@ -126,7 +126,7 @@ func get_card_in_pile_at(pile : Piles, index : int):
 	elif pile == Piles.hand_pile and _hand_pile.size() > index:
 		return _hand_pile[index]
 	return null
-		
+
 func get_card_pile_size(pile : Piles):
 	if pile == Piles.discard_pile:
 		return _discard_pile.size()
@@ -135,7 +135,7 @@ func get_card_pile_size(pile : Piles):
 	elif pile == Piles.draw_pile:
 		return _draw_pile.size()
 	return 0
-	
+
 
 
 func _maybe_remove_card_from_any_piles(card : CardUI):
@@ -148,14 +148,14 @@ func _maybe_remove_card_from_any_piles(card : CardUI):
 	elif _discard_pile.find(card) != -1:
 		_discard_pile.erase(card)
 		emit_signal("discard_pile_updated")
-		
+
 
 
 func create_card_in_dropzone(nice_name : String, dropzone : CardDropzone):
 	var card_ui = _create_card_ui(_get_card_data_by_nice_name(nice_name))
 	card_ui.position = dropzone.position
 	set_card_dropzone(card_ui, dropzone)
-			
+
 func create_card_in_pile(nice_name : String, pile_to_add_to : Piles):
 	var card_ui = _create_card_ui(_get_card_data_by_nice_name(nice_name))
 	if pile_to_add_to == Piles.hand_pile:
@@ -183,18 +183,18 @@ func get_card_dropzone(card : CardUI):
 			return dropzone
 	return null
 
-			
+
 func _get_dropzones(node: Node, className : String, result : Array) -> void:
 	if node is CardDropzone:
 		result.push_back(node)
 	for child in node.get_children():
 		_get_dropzones(child, className, result)
-	
+
 
 func load_json_path():
 	card_database = _load_json_cards_from_path(json_card_database_path)
 	card_collection = _load_json_cards_from_path(json_card_collection_path)
-	
+
 func _load_json_cards_from_path(path : String):
 	var found = []
 	if path:
@@ -230,12 +230,12 @@ func _ready():
 	load_json_path()
 	_reset_card_collection()
 	reset_target_positions()
-		
+
 func reset_target_positions():
 	_set_draw_pile_target_positions()
 	_set_hand_pile_target_positions()
 	_set_discard_pile_target_positions()
-	
+
 func _set_draw_pile_target_positions(instantly_move = false):
 	for i in _draw_pile.size():
 		var card_ui = _draw_pile[i]
@@ -266,7 +266,7 @@ func _set_draw_pile_target_positions(instantly_move = false):
 		card_ui.set_direction(Vector2.DOWN)
 		if instantly_move:
 			card_ui.position = target_pos
-	
+
 func _set_hand_pile_target_positions():
 	for i in _hand_pile.size():
 		var card_ui = _hand_pile[i]
@@ -289,7 +289,7 @@ func _set_hand_pile_target_positions():
 	while _hand_pile.size() > max_hand_size:
 		set_card_pile(_hand_pile[_hand_pile.size() - 1], Piles.discard_pile)
 	_reset_hand_pile_z_index()
-	
+
 func _set_discard_pile_target_positions():
 	for i in _discard_pile.size():
 		var card_ui = _discard_pile[i]
@@ -358,7 +358,7 @@ func is_any_card_ui_clicked():
 				return true
 	return false
 
-#public function to try and draw a card 
+#public function to try and draw a card
 func draw(num_cards := 1):
 	for i in num_cards:
 		if _hand_pile.size() >= max_hand_size and cant_draw_at_hand_limit:

--- a/addons/simple_card_pile_ui/card_ui.gd
+++ b/addons/simple_card_pile_ui/card_ui.gd
@@ -15,8 +15,8 @@ signal card_dropped(card: CardUI)
 @export var card_data : CardUIData
 
 
-var frontface_texture : String
-var backface_texture : String
+var frontface_texture : Texture2D
+var backface_texture : Texture2D
 var is_clicked := false
 var mouse_is_hovering := false
 var target_position := Vector2.ZERO
@@ -40,7 +40,7 @@ func set_disabled(val : bool):
 		var parent = get_parent()
 		if parent is CardPileUI:
 			parent.reset_card_ui_z_index()
-			
+
 func _ready():
 	if Engine.is_editor_hint():
 		set_disabled(true)
@@ -50,8 +50,8 @@ func _ready():
 	connect("mouse_exited", _on_mouse_exited)
 	connect("gui_input", _on_gui_input)
 	if frontface_texture:
-		frontface.texture = load(frontface_texture)
-		backface.texture = load(backface_texture)
+		frontface.texture = frontface_texture
+		backface.texture = backface_texture
 		custom_minimum_size = frontface.texture.get_size()
 		pivot_offset = frontface.texture.get_size() / 2
 		mouse_filter = Control.MOUSE_FILTER_PASS
@@ -70,7 +70,7 @@ func _card_can_be_interacted_with():
 		if dropzone:
 			valid = dropzone.get_top_card() == self and not parent.is_any_card_ui_clicked()
 	return valid
-			
+
 
 
 func _on_mouse_enter():
@@ -93,18 +93,18 @@ func _on_mouse_exited():
 		if parent is CardPileUI:
 			parent.reset_card_ui_z_index()
 		emit_signal("card_unhovered", self)
-	
+
 func _on_gui_input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		if event.pressed:
 			var parent = get_parent()
-			
+
 			if _card_can_be_interacted_with():
 				is_clicked = true
 				rotation = 0
 				parent.reset_card_ui_z_index()
 				emit_signal("card_clicked", self)
-			
+
 			if parent is CardPileUI and parent.get_card_pile_size(CardPileUI.Piles.draw_pile) > 0 and parent.is_hand_enabled() and parent.get_cards_in_pile(CardPileUI.Piles.draw_pile).find(self) != -1 and not parent.is_any_card_ui_clicked() and parent.click_draw_pile_to_draw:
 				parent.draw(1)
 		else:
@@ -125,7 +125,7 @@ func _on_gui_input(event):
 							break
 				emit_signal("card_dropped", self)
 				emit_signal("card_unhovered", self)
-			
+
 
 func get_dropzones(node: Node, className : String, result : Array) -> void:
 	if node is CardDropzone:
@@ -140,7 +140,7 @@ func _process(_delta):
 		position = target_position
 	elif position != target_position:
 		position = lerp(position, target_position, return_speed)
-		
+
 	if Engine.is_editor_hint() and last_child_count != get_child_count():
 		update_configuration_warnings()
 		last_child_count = get_child_count()

--- a/addons/simple_card_pile_ui/card_ui_data.gd
+++ b/addons/simple_card_pile_ui/card_ui_data.gd
@@ -2,4 +2,6 @@ class_name CardUIData extends Resource
 
 signal card_data_updated
 
+@export var frontface_texture: Texture2D
+@export var backface_texture: Texture2D
 @export var nice_name : String

--- a/example/example.gd
+++ b/example/example.gd
@@ -27,7 +27,7 @@ func _on_draw_3_button_pressed():
 
 
 func _on_sort_button_pressed():
-	card_pile_ui.sort_hand(func(a, b): 
+	card_pile_ui.sort_hand(func(a, b):
 		if a.card_data.suit == b.card_data.suit:
 			return a.card_data.value < b.card_data.value
 		else:
@@ -69,7 +69,7 @@ func _on_discard_hand_button_pressed():
 func _on_add_joker_to_dropzones_button_pressed():
 	for dropzone in dropzones:
 		card_pile_ui.create_card_in_dropzone(_get_rand_joker(), dropzone)
-		
+
 
 
 func _on_move_from_dropzone_to_pile_button_pressed():

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bayw73ve8ui7r"]
+[gd_scene load_steps=15 format=3 uid="uid://bayw73ve8ui7r"]
 
 [ext_resource type="Script" path="res://example/example.gd" id="1_0dn0o"]
 [ext_resource type="Script" path="res://addons/simple_card_pile_ui/card_pile_ui_debugger.gd" id="2_7gbt2"]
@@ -7,10 +7,21 @@
 [ext_resource type="Script" path="res://example/example__dropzone__play_by_suit.gd" id="4_cyr6y"]
 [ext_resource type="Texture2D" uid="uid://bpjxsk1mxfl77" path="res://assets/1x1_#ffffffff.png" id="4_eyd4o"]
 [ext_resource type="PackedScene" uid="uid://bs2vgjwuarxm5" path="res://example/example__card_ui.tscn" id="6_df1s4"]
+[ext_resource type="Script" path="res://addons/simple_card_pile_ui/card_db/json_file_card_db.gd" id="7_wllo0"]
+[ext_resource type="Script" path="res://addons/simple_card_pile_ui/card_db/json_file_card_collection.gd" id="8_4pkxv"]
 
 [sub_resource type="Theme" id="Theme_oqbkv"]
 Button/font_sizes/font_size = 12
 RichTextLabel/font_sizes/normal_font_size = 12
+
+[sub_resource type="Resource" id="Resource_uyfu7"]
+script = ExtResource("7_wllo0")
+json_file_path = "res://example/example__card_database.json"
+
+[sub_resource type="Resource" id="Resource_x3wkq"]
+script = ExtResource("8_4pkxv")
+json_file_path = "res://example/example__card_collection.json"
+all = []
 
 [sub_resource type="Curve" id="Curve_ayyaa"]
 min_value = -15.0
@@ -266,8 +277,8 @@ horizontal_alignment = 1
 layout_mode = 3
 anchors_preset = 0
 script = ExtResource("3_axm7s")
-json_card_database_path = "res://example/example__card_database.json"
-json_card_collection_path = "res://example/example__card_collection.json"
+card_database = SubResource("Resource_uyfu7")
+card_collection = SubResource("Resource_x3wkq")
 extended_card_ui = ExtResource("6_df1s4")
 draw_pile_layout = 2
 max_hand_size = 7

--- a/example_2/example.gd
+++ b/example_2/example.gd
@@ -18,7 +18,7 @@ var block := 0 :
 	set(val):
 		block = val
 		_update_display()
-		
+
 var mana := 4 :
 	set(val):
 		mana = val

--- a/example_2/example__card_collection.json
+++ b/example_2/example__card_collection.json
@@ -1,4 +1,4 @@
-[ 
+[
 	"Slice",
 	"Slice",
 	"Slice",


### PR DESCRIPTION
This splits the card database loading into a separate component (`CardDB`) which can be implemented however the user wishes, with `JSONFileCardDB` being a built-in option provided. `CardCollection` has also undergone a similar treatment (unfortunately, in Godot 4.2 it's not possible to provide a drop-in replacement object which can be iterated like a simple array whilst also allowing custom logic, because of godotengine/godot#74686). They are coupled to `CardPileUI` through a very simple protocol which imposes a minimal amount of requirements on the user code.

For backwards compatibility, JSON loading will still happen as a fallback if no `card_database` or `card_collection` has been provided, so existing code will continue to work unchanged. This has been tested using the examples: example 1 (ie. main scene) has been ported to use `JSONFileCardDB` explicitly, whereas example 2 uses the old deprecated `*_file_path` properties. Both work without issues.

All of the changes have been fully documented in the `README`.

Fixes #4.